### PR TITLE
2nd sprint db grid–fixes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
 
   def current_user
+    puts session[:username]
     @current_user ||= User.find_by(username: session[:username]) if session[:username]
   end
   allow_browser versions: :modern

--- a/app/controllers/grids_controller.rb
+++ b/app/controllers/grids_controller.rb
@@ -39,10 +39,13 @@ class GridsController < ApplicationController
       redirect_to grids_path
     else
       @visibility = current_user.visibility_for(@grid)
-      @cells = @grid.cells.where("cell_loc LIKE ?", "R[0-#{@visibility - 1}]C[0-#{@visibility - 1}]")
-      @cells = @cells.order(:cell_id)
-      print(@cells)
-      print(@visibility)
+      puts "STUFF"
+      # @cells = @grid.cells.where("cell_loc LIKE ?", "R[0-#{@visibility - 1}]C[0-#{@visibility - 1}]")
+      # @cells = @grid.cells.order(:cell_id)
+      numbers = (0...@visibility).to_a.map(&:to_s)
+      numbers_pattern = numbers.join('|')
+      pattern = "^R(#{numbers_pattern})C(#{numbers_pattern})$"
+      @cells = @grid.cells.where("cell_loc ~ ?", pattern).order(:cell_id)
       @grid_matrix = @cells.each_slice(@visibility).to_a
       @character = Character.find_by(username: @user.username)
     end

--- a/app/controllers/grids_controller.rb
+++ b/app/controllers/grids_controller.rb
@@ -40,7 +40,7 @@ class GridsController < ApplicationController
     else
       @visibility = current_user.visibility_for(@grid)
       numbers = (0...@visibility).to_a.map(&:to_s)
-      numbers_pattern = numbers.join('|')
+      numbers_pattern = numbers.join("|")
       pattern = "^R(#{numbers_pattern})C(#{numbers_pattern})$"
       @cells = @grid.cells.where("cell_loc ~ ?", pattern).order(:cell_id)
       @grid_matrix = @cells.each_slice(@visibility).to_a

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,7 +13,7 @@ class SessionsController < ApplicationController
       # Set up session with username instead of id
       session[:username] = @user.username  # Save username in session
       flash[:notice] = "Successfully logged in!"
-      redirect_to home_path  # Redirect to home page
+      redirect_to user_path(@user.username)  # Redirect to home page
     elsif !(@user && @user.authenticate(params[:password]))
       flash.now[:alert] = "Invalid username or password"
       render :new  # Render the login form again

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -14,19 +14,19 @@ class StoreController < ApplicationController
       redirect_to user_path(@user.username) and return
     end
 
-    if @character.shard_balance.nil?
+    if @user.shard_balance.nil?
       flash[:alert] = "Insufficient balance to purchase this item."
       redirect_to store_path and return
     end
-    if @character.shard_balance < item.cost
+    if @user.shard_balance < item.cost
       flash[:alert] = "Insufficient balance to purchase this item."
       redirect_to store_path and return
     end
     inventory = Inventory.find(@character.inv_id) # Find the inventory using the character's inventory ID
     inventory.items << item.item_id
-    @character.shard_balance -= item.cost
+    @user.shard_balance -= item.cost
 
-    if @character.save && inventory.save
+    if @user.save && @character.save && inventory.save
       flash[:notice] = "Item purchased successfully."
       redirect_to store_path
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -64,9 +64,9 @@ class UsersController < ApplicationController
       redirect_to user_path(@user.username) and return
     end
 
-    @character.shard_balance += shards_to_credit
+    @user.shard_balance += shards_to_credit
 
-    if @character.save
+    if @user.save
       flash[:notice] = "Successfully purchased #{shards_to_credit} shards."
       redirect_to user_path(@user.username)
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,7 +99,6 @@ class UsersController < ApplicationController
         character_name: @user.username,   # This should be able to modify
         username: @user.username,
         health: 100,
-        shard_balance: 0,
         experience: 0,
         level: 1,
         grid_id: 1,

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -5,6 +5,5 @@ class Character < ApplicationRecord
   belongs_to :inventory, foreign_key: :inv_id, primary_key: :inv_id
 
   validates :username, presence: true
-  validates :shard_balance, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :level, presence: true, numericality: { greater_than_or_equal_to: 1 }
 end

--- a/app/models/grid.rb
+++ b/app/models/grid.rb
@@ -11,8 +11,8 @@ class Grid < ApplicationRecord
     cells_in_grid = []
     # .. inclusive-inclusive
     # ... inclusive-exclusive
-    (0...self.size).each do |row|
-      (0...self.size).each do |col|
+    (0...GRID_SIZE).each do |row|
+      (0...GRID_SIZE).each do |col|
         # grid_id=1, row=0, col=0 => 10000
         # grid_id=20, row=3, col=5 => 200305
         cell_id = grid_id * 10_000 + row * 100 + col
@@ -36,53 +36,5 @@ class Grid < ApplicationRecord
 
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error "Something went wrong when generate grid: #{e.message}"
-  end
-
-  def expand_grid
-    old_size = self.size - 1 # 7-1
-    cells_in_grid = []
-    # Generate new cells for the new row
-    # .. inclusive-inclusive
-    (0..old_size).each do |col|
-      row = old_size
-      cell_id = grid_id * 10_000 + row * 100 + col
-      cell_loc = "R#{row}C#{col}"
-      cells_in_grid << {
-        cell_id: cell_id,
-        cell_loc: cell_loc,
-        mons_prob: rand,
-        disaster_prob: rand,
-        weather: "sunny",
-        terrain: "grass",
-        has_store: [ true, false ].sample,
-        grid_id: self.grid_id,
-        created_at: Time.current,
-        updated_at: Time.current
-      }
-    end
-
-    # Generate new cells for the new column
-    # ... inclusive-exclusive
-    (0...old_size).each do |row|
-      col = old_size
-      cell_id = grid_id * 10_000 + row * 100 + col
-      cell_loc = "R#{row}C#{col}"
-      cells_in_grid << {
-        cell_id: cell_id,
-        cell_loc: cell_loc,
-        mons_prob: rand,
-        disaster_prob: rand,
-        weather: "sunny",
-        terrain: "grass",
-        has_store: [ true, false ].sample,
-        grid_id: self.grid_id,
-        created_at: Time.current,
-        updated_at: Time.current
-      }
-    end
-
-    Cell.insert_all(cells_in_grid)
-    rescue ActiveRecord::RecordInvalid => e
-      Rails.logger.error "Something went wrong when expanding grid: #{e.message}"
   end
 end

--- a/app/models/grid.rb
+++ b/app/models/grid.rb
@@ -5,6 +5,7 @@ class Grid < ApplicationRecord
   has_many :cells, foreign_key: "grid_id", primary_key: "grid_id", dependent: :destroy
 
   after_create :generate_cells
+  GRID_SIZE = 12
 
   def generate_cells
     cells_in_grid = []

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,9 +9,11 @@ class User < ApplicationRecord
 
   # Method to get visibility for a specific grid
   def visibility_for(grid)
-    # TODO
-    print("visibility for #{grid.name} is #{user_grid_visibilities.find_by(grid_id: grid.grid_id)&.visibility}")
-    user_grid_visibilities.find_by(grid_id: grid.grid_id).visibility || 0
+    ugv = user_grid_visibilities.find_or_create_by(grid_id: grid.grid_id) do |new_ugv|
+      new_ugv.visibility = 6  # Default visibility
+    end
+    puts ugv.visibility
+    ugv.visibility
   end
 
   # Method to set visibility for a specific grid
@@ -32,6 +34,7 @@ class User < ApplicationRecord
   private
 
   def initialize_grid_visibilities
+    # puts "Initializing grid visibilities for #{self.username}"
     Grid.find_each do |grid|
       user_grid_visibilities.create!(grid_id: grid.grid_id, visibility: 6)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,12 +2,38 @@ require "open_exchange_rates"
 class User < ApplicationRecord
   has_secure_password
   has_one :character, foreign_key: "username", primary_key: "username",  dependent: :destroy
+  has_many :user_grid_visibilities, foreign_key: "username", dependent: :destroy
+  has_many :grids, through: :user_grid_visibilities
   validates :shard_balance, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  after_create :initialize_grid_visibilities
+
+  # Method to get visibility for a specific grid
+  def visibility_for(grid)
+    # TODO
+    print("visibility for #{grid.name} is #{user_grid_visibilities.find_by(grid_id: grid.grid_id)&.visibility}")
+    user_grid_visibilities.find_by(grid_id: grid.grid_id).visibility || 0
+  end
+
+  # Method to set visibility for a specific grid
+  def set_visibility_for(grid, new_visibility)
+    ugv = user_grid_visibilities.find_or_initialize_by(grid_id: grid.grid_id)
+    ugv.visibility = new_visibility
+    ugv.save
+  end
+
   OpenExchangeRates.configure do |config|
     config.app_id = "541c6dbbdf244c82bd71151575e47f27"
   end
   def get_exchange_rate(currency)
     fx = OpenExchangeRates::Rates.new
     fx.convert(1, from: "USD", to: currency)
+  end
+
+  private
+
+  def initialize_grid_visibilities
+    Grid.find_each do |grid|
+      user_grid_visibilities.create!(grid_id: grid.grid_id, visibility: 6)
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ require "open_exchange_rates"
 class User < ApplicationRecord
   has_secure_password
   has_one :character, foreign_key: "username", primary_key: "username",  dependent: :destroy
+  validates :shard_balance, presence: true, numericality: { greater_than_or_equal_to: 0 }
   OpenExchangeRates.configure do |config|
     config.app_id = "541c6dbbdf244c82bd71151575e47f27"
   end

--- a/app/models/user_grid_visibility.rb
+++ b/app/models/user_grid_visibility.rb
@@ -1,0 +1,5 @@
+class UserGridVisibility < ApplicationRecord
+  belongs_to :user, foreign_key: :username, primary_key: :username
+  belongs_to :grid, foreign_key: :grid_id, primary_key: :grid_id
+  validates :visibility, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: Grid::GRID_SIZE }
+end

--- a/app/views/grids/index.html.erb
+++ b/app/views/grids/index.html.erb
@@ -14,11 +14,6 @@
 
 <!-- Create cannot work properly -->
 <%= link_to 'Create a new grid', new_grid_path, class: 'create-button' %>
-<% if @grid %>
-  <%= button_to 'Expand', expand_grid_path(@grid), method: :patch, class: 'expand-button' %>
-<% else %>
-  <p>No grid available to expand. Create one!</p>
-<% end %>
 
 <table class="grids-table">
   <thead>

--- a/app/views/grids/show.html.erb
+++ b/app/views/grids/show.html.erb
@@ -17,7 +17,7 @@
   </div>
 
   <% if @visibility < Grid::GRID_SIZE %>
-    <%= button_to 'Expand', expand_grid_path(@grid), method: :patch, class: 'expand-button' %>
+    <%= button_to 'Expand (costs 10 shards)', expand_grid_path(@grid), method: :patch, class: 'expand-button' %>
   <% else %>
     <p>Maximum grid size reached.</p>
   <% end %>

--- a/app/views/grids/show.html.erb
+++ b/app/views/grids/show.html.erb
@@ -16,6 +16,12 @@
     <% end %>
   </div>
 
+  <% if @visibility < Grid::GRID_SIZE %>
+    <%= button_to 'Expand', expand_grid_path(@grid), method: :patch, class: 'expand-button' %>
+  <% else %>
+    <p>Maximum grid size reached.</p>
+  <% end %>
+
   <div id="cell-details" data-grid-target="details">
     <h2>Cell Details</h2>
     <div>

--- a/app/views/grids/show.html.erb
+++ b/app/views/grids/show.html.erb
@@ -16,12 +16,6 @@
     <% end %>
   </div>
 
-  <% if @visibility < Grid::GRID_SIZE %>
-    <%= button_to 'Expand', expand_grid_path(@grid), method: :patch, class: 'expand-button' %>
-  <% else %>
-    <p>Maximum grid size reached.</p>
-  <% end %>
-
   <div id="cell-details" data-grid-target="details">
     <h2>Cell Details</h2>
     <div>

--- a/app/views/grids/show.html.erb
+++ b/app/views/grids/show.html.erb
@@ -1,3 +1,5 @@
+<h1><%= @grid.name %></h1>
+
 <div data-controller="grid">
   <div class="grid-container">
     <% @grid_matrix.each do |row| %>
@@ -8,16 +10,17 @@
                data-action="click->grid#showDetails"
                data-cell-id="<%= cell.id %>">
             <%= cell.cell_loc %>
-            <% if @character && @character.cell_id == cell.cell_id %>
-              <div class="character" data-character-id="<%= @character.id %>" >
-                <%= @character.character_name %>
-              </div>
-            <% end %>
           </div>
         <% end %>
       </div>
     <% end %>
   </div>
+
+  <% if @visibility < Grid::GRID_SIZE %>
+    <%= button_to 'Expand', expand_grid_path(@grid), method: :patch, class: 'expand-button' %>
+  <% else %>
+    <p>Maximum grid size reached.</p>
+  <% end %>
 
   <div id="cell-details" data-grid-target="details">
     <h2>Cell Details</h2>
@@ -25,5 +28,4 @@
       Select a cell to see the details!
     </div>
   </div>
-
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
     <nav class="navbar">
       <ul class="nav-links">
         <li><%= link_to 'Profile', user_path(current_user.username) %></li>
+        <li> Inventory </li>
         <li><%= link_to 'Store', store_path(current_user.username) %></li>
         <li><%= link_to 'Grid', grids_path %></li>
         <li> Logout </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,6 @@
     <nav class="navbar">
       <ul class="nav-links">
         <li><%= link_to 'Profile', user_path(current_user.username) %></li>
-        <li> Inventory </li>
         <li><%= link_to 'Store', store_path(current_user.username) %></li>
         <li><%= link_to 'Grid', grids_path %></li>
         <li> Logout </li>

--- a/app/views/store/shards_store.html.erb
+++ b/app/views/store/shards_store.html.erb
@@ -3,11 +3,6 @@
   For all your shards shopping needs!!
 </p>
 <div class="store-items">
-  <% if @grid %>
-    <%= button_to 'Expand', expand_grid_path(@grid), method: :patch, class: 'expand-button' %>
-  <% else %>
-    <p>No grid available to expand. Create one!</p>
-  <% end %>
   <% @items.each do |item| %>
     <div class="item">
       <h2><%= item.name %></h2>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <div class="profile">
 <h1>Hello <%= @user.username %>!</h1>
-<p>Current balance: <%= @character.shard_balance %> shards</p>
+<p>Current balance: <%= @user.shard_balance %> shards</p>
 
 <%= link_to 'Buy more shards', buy_shards_user_path(@user.username), class: 'buy-shards' %>
   <br>

--- a/db/migrate/20241112020206_create_users.rb
+++ b/db/migrate/20241112020206_create_users.rb
@@ -4,6 +4,7 @@ class CreateUsers < ActiveRecord::Migration[7.2]
       t.string :email, null: false
       t.string :username, null: false, primary_key: true
       t.string :password_digest, null: false
+      t.integer :shard_balance, null: false
       t.timestamps
     end
     add_index :users, :username, unique: true

--- a/db/migrate/20241112020206_create_users.rb
+++ b/db/migrate/20241112020206_create_users.rb
@@ -4,7 +4,7 @@ class CreateUsers < ActiveRecord::Migration[7.2]
       t.string :email, null: false
       t.string :username, null: false, primary_key: true
       t.string :password_digest, null: false
-      t.integer :shard_balance, null: false
+      t.integer :shard_balance, null: false, default: 0
       t.timestamps
     end
     add_index :users, :username, unique: true

--- a/db/migrate/20241112023020_create_grids.rb
+++ b/db/migrate/20241112023020_create_grids.rb
@@ -2,7 +2,6 @@ class CreateGrids < ActiveRecord::Migration[7.2]
   def change
     create_table :grids, id: false do |t|
       t.integer :grid_id, primary_key: true, null: false
-      # t.integer :size, null: false
       t.string :name, null: false
       t.timestamps
     end

--- a/db/migrate/20241112023020_create_grids.rb
+++ b/db/migrate/20241112023020_create_grids.rb
@@ -2,7 +2,7 @@ class CreateGrids < ActiveRecord::Migration[7.2]
   def change
     create_table :grids, id: false do |t|
       t.integer :grid_id, primary_key: true, null: false
-      t.integer :size, null: false
+      # t.integer :size, null: false
       t.string :name, null: false
       t.timestamps
     end

--- a/db/migrate/20241112025800_create_characters.rb
+++ b/db/migrate/20241112025800_create_characters.rb
@@ -4,7 +4,6 @@ class CreateCharacters < ActiveRecord::Migration[7.2]
           t.string :character_name, null: false, primary_key: true
           t.string :username, null: false
           t.integer :health, null: false
-          t.integer :shard_balance, null: false
           t.integer :experience, null: false
           t.integer :level, null: false
           t.integer :grid_id, null: false

--- a/db/migrate/20241125052111_create_user_grid_visibilities.rb
+++ b/db/migrate/20241125052111_create_user_grid_visibilities.rb
@@ -1,0 +1,14 @@
+class CreateUserGridVisibilities < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_grid_visibilities do |t|
+      t.string :username, null: false
+      t.integer :grid_id, null: false
+      t.integer :visibility, null: false, default: 0
+
+      t.timestamps
+    end
+    add_index :user_grid_visibilities, [ :username, :grid_id ], unique: true
+    add_foreign_key :user_grid_visibilities, :users, column: :username, primary_key: :username
+    add_foreign_key :user_grid_visibilities, :grids, column: :grid_id, primary_key: :grid_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,7 +73,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_052111) do
   create_table "users", primary_key: "username", id: :string, force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest", null: false
-    t.integer "shard_balance", null: false
+    t.integer "shard_balance", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_12_025800) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_25_052111) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_12_025800) do
     t.index ["item_id"], name: "index_items_on_item_id", unique: true
   end
 
+  create_table "user_grid_visibilities", force: :cascade do |t|
+    t.string "username", null: false
+    t.integer "grid_id", null: false
+    t.integer "visibility", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["username", "grid_id"], name: "index_user_grid_visibilities_on_username_and_grid_id", unique: true
+  end
+
   create_table "users", primary_key: "username", id: :string, force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest", null: false
@@ -77,4 +86,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_12_025800) do
   add_foreign_key "characters", "grids", primary_key: "grid_id"
   add_foreign_key "characters", "inventories", column: "inv_id", primary_key: "inv_id"
   add_foreign_key "characters", "users", column: "username", primary_key: "username"
+  add_foreign_key "user_grid_visibilities", "grids", primary_key: "grid_id"
+  add_foreign_key "user_grid_visibilities", "users", column: "username", primary_key: "username"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_052111) do
   end
 
   create_table "grids", primary_key: "grid_id", id: :serial, force: :cascade do |t|
-    t.integer "size", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_12_025800) do
   create_table "characters", primary_key: "character_name", id: :string, force: :cascade do |t|
     t.string "username", null: false
     t.integer "health", null: false
-    t.integer "shard_balance", null: false
     t.integer "experience", null: false
     t.integer "level", null: false
     t.integer "grid_id", null: false
@@ -66,6 +65,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_12_025800) do
   create_table "users", primary_key: "username", id: :string, force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest", null: false
+    t.integer "shard_balance", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 # Correct seed example
-@user = User.find_or_create_by!(username: 'abcd', email: 'student@uiowa.edu') do |user|
+@user = User.find_or_create_by!(username: 'abcd', email: 'student@uiowa.edu', shard_balance: 100000) do |user|
   user.password = '54321'
   user.password_confirmation = '54321'
 end
@@ -21,15 +21,17 @@ end
 @item2 = Item.find_or_create_by!(item_id: 2, name: 'stuff', category: 'shield', cost: 1)
 
 @inventory = Inventory.find_or_create_by!(inv_id: 1, items: [ @item1, @item2 ])
-@character = Character.find_or_create_by!(username: @user.username, character_name: 'Hawkeye',
-                                shard_balance: 100000000, health: 100, experience: 0, level: 1,
-                                grid_id: @grid.grid_id, cell_id:  @first_cell.cell_id, inv_id: @inventory.inv_id)
+# Tips: We can't directly specify the cell_id as @cell.cell_id, cause cells are generated after creating grid
+# For now just set it as 1000 for simple, this should be modified as we need store characters last location
+@character = Character.find_or_create_by!(username: @user.username, character_name: 'Hawkeye', health: 100,
+                                          experience: 0, level: 1,  grid_id: @grid.grid_id,
+                                          cell_id:  @first_cell.cell_id, inv_id: @inventory.inv_id)
 
 @inventory2 = Inventory.find_or_create_by!(inv_id: 2, items: [ @item1, @item2 ])
-@user2 = User.find_or_create_by!(username: 'abcd2', email: 'student2@uiowa.edu') do |user|
+@user2 = User.find_or_create_by!(username: 'abcd2', email: 'student2@uiowa.edu', shard_balance: 100000) do |user|
   user.password = '54321'
   user.password_confirmation = '54321'
 end
 @character2 = Character.find_or_create_by!(username: @user2.username, character_name: 'Hawkeye2',
-                               shard_balance: 0, health: 100, experience: 0, level: 1,
-                               grid_id: @grid.grid_id, cell_id:  @first_cell.cell_id, inv_id: @inventory2.inv_id)
+                                           health: 100, experience: 0, level: 1, grid_id: @grid.grid_id,
+                                           cell_id:  @first_cell.cell_id, inv_id: @inventory.inv_id)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,7 @@ end
                                           cell_id:  @first_cell.cell_id, inv_id: @inventory.inv_id)
 
 @inventory2 = Inventory.find_or_create_by!(inv_id: 2, items: [ @item1, @item2 ])
-@user2 = User.find_or_create_by!(username: 'abcd2', email: 'student2@uiowa.edu', shard_balance: 100000) do |user|
+@user2 = User.find_or_create_by!(username: 'abcd2', email: 'student2@uiowa.edu', shard_balance: 20) do |user|
   user.password = '54321'
   user.password_confirmation = '54321'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,13 +12,14 @@
   user.password = '54321'
   user.password_confirmation = '54321'
 end
-@grid = Grid.find_or_create_by!(grid_id: 1, size: 6, name: 'earth')
+@grid = Grid.find_or_create_by!(grid_id: 1, name: 'earth')
+@grid2 = Grid.find_or_create_by!(grid_id: 2, name: 'moon')
 # Tips: No need to instantiate a cell, since grid will generate cells after creating automatically!
 # @cell = Cell.find_or_create_by!(cell_id: 1, cell_loc: '1A', mons_prob: 0.3, disaster_prob: 0.3, weather: 'Sunny',
 #                                 terrain: 'desert', has_store: true, grid_id: @grid.grid_id)
 @first_cell = @grid.cells.order(:cell_id).first
-@item1 = Item.find_or_create_by!(item_id: 1, name: 'thingy', category: 'sword', cost: 1)
-@item2 = Item.find_or_create_by!(item_id: 2, name: 'stuff', category: 'shield', cost: 1)
+@item1 = Item.find_or_create_by!(item_id: 1, name: 'Mediocre Sword', category: 'Weapon', cost: 1)
+@item2 = Item.find_or_create_by!(item_id: 2, name: 'Health Pack', category: 'Support', cost: 1)
 
 @inventory = Inventory.find_or_create_by!(inv_id: 1, items: [ @item1, @item2 ])
 # Tips: We can't directly specify the cell_id as @cell.cell_id, cause cells are generated after creating grid

--- a/features/add_balance.feature
+++ b/features/add_balance.feature
@@ -4,21 +4,21 @@ Feature: Add balance in profile
   so I can buy more things
 
   Scenario: User adds dollar
-    Given I have an account
+    Given I have an account and logged in
     And I have a balance of $0
     When I go to my profile page
     And I buy 10 USD worth of shards with a credit card
     Then my current balance should have 10 shards
 
   Scenario: User adds euros
-    Given I have an account
+    Given I have an account and logged in
     And I have a balance of $0
     When I go to my profile page
     And I buy 10 EUR worth of shards with a credit card
     Then my current balance should have at least 1 shards
 
   Scenario: User adds negative
-    Given I have an account
+    Given I have an account and logged in
     And I have a balance of $0
     When I go to my profile page
     And I buy -10 EUR worth of shards with a credit card

--- a/features/check_balance.feature
+++ b/features/check_balance.feature
@@ -4,7 +4,7 @@ Feature: Check balance in profile
   So I know how much money I have
 
   Scenario: User checks their balance
-    Given I have an account
+    Given I have an account and logged in
     And I have a balance of $100
     When I go to my profile page
     Then I should see my current balance

--- a/features/delete_account.feature
+++ b/features/delete_account.feature
@@ -4,7 +4,7 @@ Feature: Delete account in profile
   So that I remove myself from the game.
 
   Scenario: User deletes their account
-    Given I have an account
+    Given I have an account and logged in
     And I go to my profile page
     And I delete my account
     Then my account should be deleted

--- a/features/expand_grid.feature
+++ b/features/expand_grid.feature
@@ -1,0 +1,29 @@
+Feature: Grid Expansion
+  As a user
+  I want to expand my grid
+  So that I can explore more areas
+
+  Background:
+    Given a grid named "Test Grid" exists
+    And I am logged in as "testuser"
+
+  Scenario: User expands the grid successfully
+    Given my grid visibility is 6
+    When I am on the grid page for "Test Grid"
+    And I click the "Expand" button
+    Then I should see a grid of size 7x7
+    And my grid visibility should be 7
+    And I should see a success message "Grid expanded successfully"
+
+  Scenario: User reaches maximum grid size
+    Given my grid visibility is 12
+    When I am on the grid page for "Test Grid"
+    Then I should not see the "Expand" button
+    And I should see a message "Maximum grid size reached."
+
+#  Scenario: Unauthorized user cannot expand another user's grid
+#    Given another user "otheruser" exists
+#    And "otheruser" has a grid visibility of 6 for "Test Grid"
+#    When I visit the grid page for "Test Grid" as "otheruser"
+#    Then I should see an authorization error
+#    And I should be redirected to the home page

--- a/features/step_definitions/grid_steps.rb
+++ b/features/step_definitions/grid_steps.rb
@@ -1,0 +1,76 @@
+Given('a grid named {string} exists') do |grid_name|
+  @grid = Grid.find_or_create_by!(grid_id: 1, name: grid_name)
+end
+
+Given('I am logged in as {string}') do |username|
+  @user = User.create!(
+    username: username,
+    email: "#{username}@example.com",
+    password: 'password',
+    password_confirmation: 'password',
+    shard_balance: 100
+  )
+  visit login_path
+  fill_in 'Username', with: @user.username
+  fill_in 'Password', with: 'password'
+  click_button 'Log In'
+end
+
+Given('my grid visibility is {int}') do |visibility|
+  @user.set_visibility_for(@grid, visibility)
+end
+
+When('I am on the grid page for {string}') do |grid_name|
+  visit grid_path(@grid)
+end
+
+When('I click the {string} button') do |button_text|
+  click_button button_text
+end
+
+Then('I should see a grid of size {int}x{int}') do |rows, cols|
+  expect(page).to have_selector('.grid-row', count: rows)
+  # Assuming each row has 'cols' number of cells
+  total_cells = rows * cols
+  expect(page).to have_selector('.grid-cell', count: total_cells)
+end
+
+Then('my grid visibility should be {int}') do |visibility|
+  expect(@user.visibility_for(@grid)).to eq(visibility)
+end
+
+Then('I should see a success message {string}') do |message|
+  expect(page).to have_content(message)
+end
+
+Then('I should not see the {string} button') do |button_text|
+  expect(page).not_to have_button(button_text)
+end
+
+Then('I should see a message {string}') do |message|
+  expect(page).to have_content(message)
+end
+
+Given('another user {string} exists') do |username|
+  @other_user = User.create!(
+    username: username,
+    email: "#{username}@example.com",
+    password: 'password',
+    password_confirmation: 'password',
+    shard_balance: 100
+  )
+end
+
+Given('{string} has a grid visibility of {int} for {string}') do |username, visibility, grid_name|
+  user = User.find_by(username: username)
+  grid = Grid.find_by(name: grid_name)
+  user.set_visibility_for(grid, visibility)
+end
+
+When('I visit the grid page for {string} as {string}') do |username|
+  visit grid_path(@grid)
+end
+
+Then('I should be redirected to the home page') do
+  expect(current_path).to eq(root_path)
+end

--- a/features/step_definitions/user_profile_steps.rb
+++ b/features/step_definitions/user_profile_steps.rb
@@ -1,32 +1,37 @@
-Given(/^I have an account$/) do
-  @user = User.create!(username: 'awesomehawkeye', email: 'awesome@uiowa.edu', password_digest: '12345')
-  @grid = Grid.create!(grid_id: 1, name: 'earth')
+Given(/^I have an account and logged in$/) do
+  @user = User.create!(
+    username: 'awesomehawkeye',
+    email: 'awesome@uiowa.edu',
+    password: '12345',
+    password_confirmation: '12345',
+    shard_balance: 0
+  )
+  @grid = Grid.create!(grid_id: 1, size: 10, name: 'earth')
   @cell = Cell.create!(cell_id: 1, cell_loc: '1A', mons_prob: 0.3, disaster_prob: 0.3, weather: 'Sunny',
                        terrain: 'desert', has_store: true, grid_id: @grid.grid_id)
   @item1 = Item.create!(item_id: 1, name: 'thingy', category: 'sword', cost: 1)
   @item2 = Item.create!(item_id: 2, name: 'stuff', category: 'shield', cost: 1)
 
   @inventory = Inventory.create!(inv_id: 1, items: [ @item1, @item2 ])
-  @character = Character.create!(username: @user.username, character_name: 'Hawkeye',
-                                    shard_balance: 0, health: 100, experience: 0, level: 1,
-                                    grid_id: @grid.grid_id, cell_id: @cell.cell_id, inv_id: @inventory.inv_id)
-  # visit new_user_session_path
-  # fill_in 'Email', with: @user.email
-  # fill_in 'Password', with: 'password'
-  # click_button 'Log in'
+  @character = Character.create!(username: @user.username, character_name: 'Hawkeye', health: 100,
+                                 experience: 0, level: 1, grid_id: @grid.grid_id, cell_id: @cell.cell_id,
+                                 inv_id: @inventory.inv_id)
+  visit login_path
+  fill_in 'Username', with: 'awesomehawkeye'
+  fill_in 'Password', with: '12345'
+  click_button 'Log In'
 end
 
 Given(/^I have a balance of \$(\d+)$/) do |amount|
-  @character = Character.update!(shard_balance: amount.to_f)
+  @user.update!(shard_balance: amount.to_f)
 end
 
 When(/^I go to my profile page$/) do
-  visit user_path(@user.username)
+  click_link 'Profile'
 end
 
 Then(/^I should see my current balance$/) do
-  @character = Character.find_by(username: @user.username)
-  expect(page).to have_content("Current balance: #{@character.shard_balance} shards")
+  expect(page).to have_content("Current balance: #{@user.shard_balance} shards")
 end
 
 When(/^I buy (-?\d+) (USD|EUR) worth of shards with a credit card$/) do |amount, currency|
@@ -54,19 +59,9 @@ end
 
 When(/^I delete my account$/) do
   click_button('Delete account')
-  # page.driver.browser.switch_to.alert.accept rescue Selenium::WebDriver::Error::NoAlertOpenError
-  # expect(page).to have_content('Your account has been successfully deleted.')
 end
 
 Then(/^my account should be deleted$/) do
   # expect(page).to have_current_path(root_path)
   expect(page).to have_content('Your account has been successfully deleted.')
-end
-
-Then(/^I click on 10 shards$/) do
-  find('#shards_10').click
-end
-
-Then(/^I should see payment amount updated to 10$/) do
-  expect(page).to have_selector('#price', text: '10.00')
 end

--- a/spec/models/user_grid_visibility_spec.rb
+++ b/spec/models/user_grid_visibility_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserGridVisibility, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Description

Resolving current issues on main

## Changes

- Re-assigning shards from character to user attribute in scheme.rb; relevant code in stores and balance are fixed as well
- Instead of each grid having a variable, expandable size, I introduced a user-grid join table, with visibility as an attribute. It works as follows: (1) ALL grids are universal (same cell information across users) have a fixed size of 12x12 (2) ALL users can only access 6x6 grids in the beginning, unless they purchase them in the grids page. And it becomes 7x7, with that user's visibility becomes 7. Max is 12x12, and users get an alert which prohibits them to purchase anymore. (3) Different users have different visibilities, so they will see different grid sizes on screen. 
- Correspondingly, "size" attribute is deleted. Run db reset!
- This should help a lot with future multiplayer features, since displayed grids are different among users now!

## Additional Information/ Questions 

Thanks @adavis72 for the "expand" code in store, I appropriated it to my purpose here.

## Checklist

- [X] Code is formatted properly
- [X] Cucumber tests pass
- [X] RSpecs tests pass
- [ ] Code has been reviewed by multiple team members
- [X] Code runs locally
- [ ] Code runs on Heroku
      
