### PR TITLE
Buying worlds

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -167,3 +167,22 @@
     color: red;
     margin-top: 10px;
 }
+
+.store-items, .store-grids {
+    display: flex;           /* Use flexbox for the layout */
+    flex-wrap: wrap;         /* Allow wrapping to new lines if there are too many items */
+    gap: 20px;               /* Space between items */
+    justify-content: flex-start; /* Align items to the start of the container */
+}
+
+/* Style each item inside the container */
+.store-items .item, .store-grids .grid {
+    border: 1px solid #ccc;
+    padding: 20px;
+    text-align: center;
+    width: 200px;             /* Set width of each item */
+    box-sizing: border-box;  /* Ensure padding and border are included in the total width */
+    border-radius: 8px;      /* Optional: Round the corners */
+    background-color: #f9f9f9;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1); /* Optional: Add some shadow for a nicer effect */
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -168,7 +168,7 @@
     margin-top: 10px;
 }
 
-.store-items, .store-grids {
+.store-items, .store-grids, .owned-grids {
     display: flex;           /* Use flexbox for the layout */
     flex-wrap: wrap;         /* Allow wrapping to new lines if there are too many items */
     gap: 20px;               /* Space between items */
@@ -176,7 +176,7 @@
 }
 
 /* Style each item inside the container */
-.store-items .item, .store-grids .grid {
+.store-items .item, .store-grids .grid, .owned-grids .grid {
     border: 1px solid #ccc;
     padding: 20px;
     text-align: center;

--- a/app/controllers/grids_controller.rb
+++ b/app/controllers/grids_controller.rb
@@ -3,6 +3,10 @@ class GridsController < ApplicationController
 
   def index
     @grids = Grid.all
+    @grids = Grid.all.select do |grid|
+      user_grid_visibility = UserGridVisibility.find_by(username: @user.username, grid_id: grid.grid_id)
+      user_grid_visibility && user_grid_visibility.visibility >= 6
+    end
   end
 
   def new

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -50,14 +50,23 @@ class StoreController < ApplicationController
     @user.shard_balance -= @grid.cost
     @user.save
 
-    # Create a new user_grid_visibility record to grant the grid to the user
-    user_grid_visibility = UserGridVisibility.create(
-      username: @user.username,
-      grid_id: @grid.grid_id,
-      visibility: 1  # Set to "purchased"/"visible" status
-    )
+    # Check if the user already has visibility for this grid
+    user_grid_visibility = UserGridVisibility.find_by(username: @user.username, grid_id: @grid.id)
 
-    if user_grid_visibility.persisted?
+    if user_grid_visibility
+      # If the visibility record exists, update visibility to 6 (purchased/visible)
+      user_grid_visibility.update(visibility: 6)
+    else
+      # If no record exists, create a new one with visibility set to 6
+      user_grid_visibility = UserGridVisibility.create(
+        username: @user.username,
+        grid_id: @grid.id,
+        visibility: 6
+      )
+    end
+
+    # Check if the operation was successful
+    if user_grid_visibility.persisted? || user_grid_visibility.valid?
       flash[:notice] = "Grid purchased successfully!"
       redirect_to store_path(@user.username)
     else
@@ -65,4 +74,5 @@ class StoreController < ApplicationController
       redirect_to store_path(@user.username)
     end
   end
+
 end

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -4,6 +4,7 @@ class StoreController < ApplicationController
     @character = Character.find_by(username: params[:username])
     @items = Item.all
     @grid = Grid.find_by(grid_id: params[:id])
+    @grids = Grid.all
   end
   def buy_item
     @user = User.find_by!(username: params[:username])
@@ -32,6 +33,36 @@ class StoreController < ApplicationController
     else
       flash[:alert] = "Unable to purchase item."
       redirect_to store_path
+    end
+  end
+
+  def buy_grid
+    @user = User.find_by!(username: params[:username])
+    @grid = Grid.find(params[:id])
+
+    # Check if user has sufficient shard balance
+    if @user.shard_balance < @grid.cost
+      flash[:alert] = "You do not have enough shards to purchase this grid."
+      redirect_to store_path(@user.username) and return
+    end
+
+    # Deduct shards from user's balance
+    @user.shard_balance -= @grid.cost
+    @user.save
+
+    # Create a new user_grid_visibility record to grant the grid to the user
+    user_grid_visibility = UserGridVisibility.create(
+      username: @user.username,
+      grid_id: @grid.grid_id,
+      visibility: 1  # Set to "purchased"/"visible" status
+    )
+
+    if user_grid_visibility.persisted?
+      flash[:notice] = "Grid purchased successfully!"
+      redirect_to store_path(@user.username)
+    else
+      flash[:alert] = "There was an error purchasing the grid."
+      redirect_to store_path(@user.username)
     end
   end
 end

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -74,5 +74,4 @@ class StoreController < ApplicationController
       redirect_to store_path(@user.username)
     end
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
 
   def initialize_grid_visibilities
     Grid.find_each do |grid|
-      visibility = (grid.name == 'earth') ? 6 : 0  # Set visibility to 6 for Earth, 0 for all other grids
+      visibility = (grid.name == 'Earth') ? 6 : 0  # Set visibility to 6 for Earth, 0 for all other grids
       user_grid_visibilities.create!(grid_id: grid.grid_id, visibility: visibility)
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,9 +34,9 @@ class User < ApplicationRecord
   private
 
   def initialize_grid_visibilities
-    # puts "Initializing grid visibilities for #{self.username}"
     Grid.find_each do |grid|
-      user_grid_visibilities.create!(grid_id: grid.grid_id, visibility: 6)
+      visibility = (grid.name == 'earth') ? 6 : 0  # Set visibility to 6 for Earth, 0 for all other grids
+      user_grid_visibilities.create!(grid_id: grid.grid_id, visibility: visibility)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
 
   def initialize_grid_visibilities
     Grid.find_each do |grid|
-      visibility = (grid.name == 'Earth') ? 6 : 0  # Set visibility to 6 for Earth, 0 for all other grids
+      visibility = (grid.name == "Earth") ? 6 : 0  # Set visibility to 6 for Earth, 0 for all other grids
       user_grid_visibilities.create!(grid_id: grid.grid_id, visibility: visibility)
     end
   end

--- a/app/views/grids/index.html.erb
+++ b/app/views/grids/index.html.erb
@@ -22,7 +22,7 @@
   </tr>
   </thead>
   <tbody>
-  <% @grids.each do |grid| %>
+  <% @user_visible_grids.each do |grid| %>
     <tr>
 <!--      <td><%#= grid.grid_id %></td>-->
       <td><%= grid.name %></td>

--- a/app/views/grids/index.html.erb
+++ b/app/views/grids/index.html.erb
@@ -12,13 +12,11 @@
   </div>
 <% end %>
 
-<!-- Create cannot work properly -->
-<%= link_to 'Create a new grid', new_grid_path, class: 'create-button' %>
 
 <table class="grids-table">
   <thead>
   <tr>
-    <th>Grid ID</th>
+<!--    <th>Grid ID</th>-->
     <th>Name</th>
     <th>Operation</th>
   </tr>
@@ -26,12 +24,10 @@
   <tbody>
   <% @grids.each do |grid| %>
     <tr>
-      <td><%= grid.grid_id %></td>
+<!--      <td><%#= grid.grid_id %></td>-->
       <td><%= grid.name %></td>
       <td>
-        <%= link_to 'View', grid_path(grid) %> |
-        <%= link_to 'Edit', edit_grid_path(grid) %> |
-        <%= link_to 'Delete', grid_path(grid), method: :delete, data: { confirm: 'Are you sure you want to delete this grid?' } %>
+        <%= link_to 'View', grid_path(grid) %>
       </td>
     </tr>
   <% end %>

--- a/app/views/grids/index.html.erb
+++ b/app/views/grids/index.html.erb
@@ -22,7 +22,7 @@
   </tr>
   </thead>
   <tbody>
-  <% @user_visible_grids.each do |grid| %>
+  <% @grids.each do |grid| %>
     <tr>
 <!--      <td><%#= grid.grid_id %></td>-->
       <td><%= grid.name %></td>

--- a/app/views/store/shards_store.html.erb
+++ b/app/views/store/shards_store.html.erb
@@ -41,7 +41,7 @@
 <h2>Your Owned Grids</h2>
 <div class="owned-grids">
   <% @user.user_grid_visibilities.each do |visibility| %>
-    <% if visibility.visibility == 6 %> <!-- Show grids that are purchased -->
+    <% if visibility.visibility >= 6 %> <!-- Show grids that are purchased -->
       <div class="grid">
         <h3><%= visibility.grid.name %></h3>
       </div>

--- a/app/views/store/shards_store.html.erb
+++ b/app/views/store/shards_store.html.erb
@@ -14,3 +14,36 @@
     </div>
   <% end %>
 </div>
+
+<h2>Available Grids for Purchase</h2>
+<div class="store-grids">
+  <% if @grids.present? %>
+    <% @grids.each do |grid| %>
+      <% # Check if the user already owns this grid (visibility = 0) %>
+      <% user_grid_visibility = UserGridVisibility.find_by(username: @user.username, grid_id: grid.grid_id) %>
+      <% if user_grid_visibility.nil? || user_grid_visibility.visibility == 0 %> <!-- Grid is either not owned or visible for purchase -->
+        <div class="grid">
+          <h3><%= grid.name %></h3>
+<!--          <p>Cost: <%#= grid.cost %> shards</p>-->
+
+          <%= form_with(url: buy_grid_path(username: @user.username, id: grid.id), method: :post, local: true) do |form| %>
+            <%= form.submit 'Buy Now', class: 'buy-button' %>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  <% else %>
+    <p>No grids available for purchase.</p>
+  <% end %>
+</div>
+
+<h2>Your Owned Grids</h2>
+<div class="owned-grids">
+  <% @user.user_grid_visibilities.each do |visibility| %>
+    <% if visibility.visibility == 1 %> <!-- Show grids that are purchased -->
+      <div class="grid">
+        <h3><%= visibility.grid.name %></h3>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/store/shards_store.html.erb
+++ b/app/views/store/shards_store.html.erb
@@ -7,7 +7,7 @@
     <div class="item">
       <h2><%= item.itemable.name %></h2>
       <p><%= item.category %></p>
-      <p>Price: $<%= item.cost %></p>
+      <p>Price: <%= item.cost%> shards</p>
       <%= form_with(url: buy_item_path(@user.username, item.id), method: :post, local: true) do |form| %>
         <%= form.submit 'Buy Now', class: 'buy-button' %>
       <% end %>
@@ -21,10 +21,11 @@
     <% @grids.each do |grid| %>
       <% # Check if the user already owns this grid (visibility = 0) %>
       <% user_grid_visibility = UserGridVisibility.find_by(username: @user.username, grid_id: grid.grid_id) %>
-      <% if user_grid_visibility.nil? || user_grid_visibility.visibility == 0 %> <!-- Grid is either not owned or visible for purchase -->
+      <% if user_grid_visibility.nil? || user_grid_visibility.visibility == 0 %>
+        <!-- Grid is either not owned or visible for purchase -->
         <div class="grid">
           <h3><%= grid.name %></h3>
-<!--          <p>Cost: <%#= grid.cost %> shards</p>-->
+          <p>Price: <%= grid.cost %> shards</p>
 
           <%= form_with(url: buy_grid_path(username: @user.username, id: grid.id), method: :post, local: true) do |form| %>
             <%= form.submit 'Buy Now', class: 'buy-button' %>
@@ -40,7 +41,7 @@
 <h2>Your Owned Grids</h2>
 <div class="owned-grids">
   <% @user.user_grid_visibilities.each do |visibility| %>
-    <% if visibility.visibility == 1 %> <!-- Show grids that are purchased -->
+    <% if visibility.visibility == 6 %> <!-- Show grids that are purchased -->
       <div class="grid">
         <h3><%= visibility.grid.name %></h3>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,10 @@ Rails.application.routes.draw do
     post "buy", to: "store#buy_item", as: "buy_item"
   end
 
+  resources :store, only: [] do
+    post 'buy_grid', on: :collection
+  end
+  post 'store/:username/buy_grid/:id', to: 'store#buy_grid', as: 'buy_grid'
   # Character create and update
   post "create_character", to: "characters#create", as: "create_character"
   resources :characters, param: :username, only: [ :new, :create, :update ] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,9 +43,9 @@ Rails.application.routes.draw do
   end
 
   resources :store, only: [] do
-    post 'buy_grid', on: :collection
+    post "buy_grid", on: :collection
   end
-  post 'store/:username/buy_grid/:id', to: 'store#buy_grid', as: 'buy_grid'
+  post "store/:username/buy_grid/:id", to: "store#buy_grid", as: "buy_grid"
   # Character create and update
   post "create_character", to: "characters#create", as: "create_character"
   resources :characters, param: :username, only: [ :new, :create, :update ] do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,6 +54,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_052111) do
 
   create_table "grids", primary_key: "grid_id", id: :serial, force: :cascade do |t|
     t.string "name", null: false
+    t.integer "cost", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -64,11 +64,14 @@ end
   character.current_exp = 0
 end
 
-user2_grid1 = UserGridVisibility.find_or_create_by!(username: @user2.username, grid_id: @grid.grid_id)
-user2_grid1.update(visibility: 6) # Set visibility to 6 for purchased grid
+UserGridVisibility.find_or_create_by!(username: @user2.username, grid_id: @grid.grid_id) do |visibility|
+  visibility.visibility = 6
+end
 
-user2_grid2 = UserGridVisibility.find_or_create_by!(username: @user2.username, grid_id: @grid2.grid_id)
-user2_grid2.update(visibility: 0) # Set visibility to 0 for unpurchased grid
+UserGridVisibility.find_or_create_by!(username: @user2.username, grid_id: @grid2.grid_id) do |visibility|
+  visibility.visibility = 0
+end
 
-user2_grid3 = UserGridVisibility.find_or_create_by!(username: @user2.username, grid_id: @grid3.grid_id)
-user2_grid3.update(visibility: 0)
+UserGridVisibility.find_or_create_by!(username: @user2.username, grid_id: @grid3.grid_id) do |visibility|
+  visibility.visibility = 0
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,6 +18,10 @@ end
 # Tips: No need to instantiate a cell, since grid will generate cells after creating automatically!
 # @cell = Cell.find_or_create_by!(cell_id: 1, cell_loc: '1A', mons_prob: 0.3, disaster_prob: 0.3, weather: 'Sunny',
 #                                 terrain: 'desert', has_store: true, grid_id: @grid.grid_id)
+
+UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid.grid_id, visibility: 1)
+UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid2.grid_id, visibility: 1)
+
 @first_cell = @grid.cells.order(:cell_id).first
 @wooden_sword = Weapon.find_or_create_by!(name: 'Wooden Sword', atk_bonus: 30)
 @leather_armor = Armor.find_or_create_by!(name: 'Leather Armor', def_bonus: 10)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,9 +20,18 @@ end
 # @cell = Cell.find_or_create_by!(cell_id: 1, cell_loc: '1A', mons_prob: 0.3, disaster_prob: 0.3, weather: 'Sunny',
 #                                 terrain: 'desert', has_store: true, grid_id: @grid.grid_id)
 
-UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid.grid_id, visibility: 6)
-UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid2.grid_id, visibility: 6)
-UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid3.grid_id, visibility: 0)
+UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid.grid_id) do |visibility|
+  visibility.visibility = 6 # Set to 6 for purchased visibility
+end
+
+UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid2.grid_id) do |visibility|
+  visibility.visibility = 6
+end
+
+UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid3.grid_id) do |visibility|
+  visibility.visibility = 0 # Set to 0 if not purchased
+end
+
 
 @first_cell = @grid.cells.order(:cell_id).first
 @wooden_sword = Weapon.find_or_create_by!(name: 'Wooden Sword', atk_bonus: 30)
@@ -54,3 +63,12 @@ end
   character.current_hp = character.max_hp
   character.current_exp = 0
 end
+
+user2_grid1 = UserGridVisibility.find_or_create_by!(username: @user2.username, grid_id: @grid.grid_id)
+user2_grid1.update(visibility: 6) # Set visibility to 6 for purchased grid
+
+user2_grid2 = UserGridVisibility.find_or_create_by!(username: @user2.username, grid_id: @grid2.grid_id)
+user2_grid2.update(visibility: 0) # Set visibility to 0 for unpurchased grid
+
+user2_grid3 = UserGridVisibility.find_or_create_by!(username: @user2.username, grid_id: @grid3.grid_id)
+user2_grid3.update(visibility: 0)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,9 +13,14 @@
   user.password_confirmation = '54321'
   user.shard_balance = 100000000
 end
-@grid = Grid.find_or_create_by!(grid_id: 1, name: 'earth', cost: 20)
-@grid2 = Grid.find_or_create_by!(grid_id: 2, name: 'moon', cost: 20)
-@grid3 = Grid.find_or_create_by!(grid_id: 3, name: 'mars', cost: 20)
+@grid = Grid.find_or_create_by!(grid_id: 1, name: 'Earth', cost: 20)
+@grid2 = Grid.find_or_create_by!(grid_id: 2, name: 'Moon', cost: 20)
+@grid3 = Grid.find_or_create_by!(grid_id: 3, name: 'Mars', cost: 20)
+@grid4 = Grid.find_or_create_by!(grid_id: 4, name: 'Venus', cost: 25)
+@grid5 = Grid.find_or_create_by!(grid_id: 5, name: 'Saturn', cost: 30)
+@grid6 = Grid.find_or_create_by!(grid_id: 6, name: 'Jupiter', cost: 30)
+@grid7 = Grid.find_or_create_by!(grid_id: 7, name: 'Neptune', cost: 35)
+@grid8 = Grid.find_or_create_by!(grid_id: 8, name: 'Pluto', cost: 50)
 # Tips: No need to instantiate a cell, since grid will generate cells after creating automatically!
 # @cell = Cell.find_or_create_by!(cell_id: 1, cell_loc: '1A', mons_prob: 0.3, disaster_prob: 0.3, weather: 'Sunny',
 #                                 terrain: 'desert', has_store: true, grid_id: @grid.grid_id)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,14 +13,16 @@
   user.password_confirmation = '54321'
   user.shard_balance = 100000000
 end
-@grid = Grid.find_or_create_by!(grid_id: 1, name: 'earth')
-@grid2 = Grid.find_or_create_by!(grid_id: 2, name: 'moon')
+@grid = Grid.find_or_create_by!(grid_id: 1, name: 'earth', cost: 20)
+@grid2 = Grid.find_or_create_by!(grid_id: 2, name: 'moon', cost: 20)
+@grid3 = Grid.find_or_create_by!(grid_id: 3, name: 'mars', cost: 20)
 # Tips: No need to instantiate a cell, since grid will generate cells after creating automatically!
 # @cell = Cell.find_or_create_by!(cell_id: 1, cell_loc: '1A', mons_prob: 0.3, disaster_prob: 0.3, weather: 'Sunny',
 #                                 terrain: 'desert', has_store: true, grid_id: @grid.grid_id)
 
-UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid.grid_id, visibility: 1)
-UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid2.grid_id, visibility: 1)
+UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid.grid_id, visibility: 6)
+UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid2.grid_id, visibility: 6)
+UserGridVisibility.find_or_create_by!(username: @user.username, grid_id: @grid3.grid_id, visibility: 0)
 
 @first_cell = @grid.cells.order(:cell_id).first
 @wooden_sword = Weapon.find_or_create_by!(name: 'Wooden Sword', atk_bonus: 30)


### PR DESCRIPTION
## Description

The purpose of this PR was to add buying grids/worlds functionality to the store, so that users can buy more worlds to play in and only be able to see the worlds they have bought.

## Changes

- Moved buying worlds to the store page
- Can only see the grids user has access to on Grids page
- Default grid for new user is earth which should populate for any new user
- Added more worlds to the databse
- Removed unneeded buttons from the grids page
- Updated UI on store page 

## Additional Information/ Questions 
Please test for the users we already have seeded and for creating a new user - have tested on my own with new and existing users as well as buying worlds and expanding current. Retest and make sure all still works on your branch!
**NOTE:**  I use visibility as the flag for if a grid is purchased or not. The grid is unaccessible if they don't own it and it's size is 0 but once they buy the grid it sets the grid size to 6 and they are then still able to expand from there. Let me know if you guys have any questions! 

## Checklist

- [ ] Code is formatted properly
- [ ] Cucumber tests pass
- [ ] RSpecs tests pass
- [ ] Code has been reviewed by multiple team members
- [ ] Code runs locally
- [ ] Code runs on Heroku
      
